### PR TITLE
Fix DBD::mysql version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires "DBI";
-requires "DBD::mysql", ">= 4.030, < 5.001"
+requires "DBD::mysql", ">= 4.030, < 5.001";
 requires "Time::Piece";
 requires "Carp";
 requires "Test::More";

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires "DBI";
-requires "DBD::mysql", 4.030;
+requires "DBD::mysql", ">= 4.030, < 5.001"
 requires "Time::Piece";
 requires "Carp";
 requires "Test::More";


### PR DESCRIPTION
As of DBD::MySQL 5.001, only supports MySQL 8.0 series.

https://github.com/perl5-dbi/DBD-mysql/releases/tag/5_001


Basically, ytkit depends on libmysqlclient on os package repo.
Fix the version now but I will drop old libmysqlclient ( old os ) support someday.